### PR TITLE
Support for Payment Intents

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,16 @@ You can also customize the appearance of Stripe elements using the `style` key u
     }
 }
 ```
+
+## Backend Platform Support
+Each back-end platform handles Stripe payment method processing in its own way. Due to this, it is difficult to support all platforms until each one has been specifically tested and accounted for. The following back-end platforms are supported.
+
+* **Magento 2** (partial support). The official Stripe module for Magento 2 does not currently support checkout via API, so there are some adjustments that need to be made on their side before this module will be fully supported on Magento 2.
+
+To specify your backend platform for this module to handle it, if it is supported, add the `backend_platform` attribute in `config/local.json`. For example:
+```json
+"stripe": {
+    "apiKey": "my_example_api_key",
+    "backend_platform": "magento2"
+}
+```


### PR DESCRIPTION
Closes #21 

**Disclaimer** - I have added some support for Magento 2 as far as how the token data should be formatted (discussed in #17 ) as part of this since we had to modify the way Stripe initiates the transaction. However, the Stripe Magento 2 module doesn't work via API in its current state, so these changes support as much as this module can, but now it depends on the back-end platforms to handle the rest. I have started conversations with Stripe to discuss the changes necessary on their module for supporting API checkout. I will try to update the issue linked above when I have any updates.

Due to the above disclaimer, I don't know if you'd prefer to wait on this or not. As it stands this module doesn't work with Magento 2 anyway (in my testing) so it's not like it breaks anything as far as M2 goes. I don't know about the other platforms already in use with this module.