### PR TITLE
README file update

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,6 @@ To specify your backend platform for this module to handle it, if it is supporte
 ```json
 "stripe": {
     "apiKey": "my_example_api_key",
-    "backend_platform": "magento2",
+    "backendPlatform": "magento2",
     "paymentMethodCode": "stripe_payments"
 ```


### PR DESCRIPTION
Key to mention backend platform inside stripe object in config file should be "backendPlatform", instead of "backend_platform".