### PR TITLE
Stripe options

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,25 @@ You can also customize the appearance of Stripe elements using the `style` key u
 }
 ```
 
+You can specifiy the card initialisation options with the `options` key. You can pass any the properites found [here](https://stripe.com/docs/js/elements_object/create_element?type=card)
+```json
+"stripe": {
+    "apiKey": "my_example_api_key",
+    "style": {
+        "base": {
+            "fontSize": "16px",
+            "color": "#32325d"
+        },
+        "invalid": {
+            "color": "#fa755a"
+        }
+    },
+    "options": {
+        "hidePostalCode": true
+    }
+}
+```
+
 ## Backend Platform Support
 Each back-end platform handles Stripe payment method processing in its own way. Due to this, it is difficult to support all platforms until each one has been specifically tested and accounted for. The following back-end platforms are supported.
 

--- a/components/PaymentStripe.vue
+++ b/components/PaymentStripe.vue
@@ -106,9 +106,14 @@ export default {
     },
     createElements () {
       let style = this.stripeConfig.hasOwnProperty('style') ? this.stripeConfig.style : {}
-
+      let options = this.stripeConfig.hasOwnProperty('options') ? this.stripeConfig.options : {};
+      let cardOptions = {};
+      cardOptions.style = style;
+      Object.keys(options).forEach(function (option) {
+        cardOptions[option] = options[option];
+      });
       // Create an instance of the card Element.
-      this.stripe.card = this.stripe.elements.create('card', { style: style })
+      this.stripe.card = this.stripe.elements.create('card', cardOptions)
 
       // Add an instance of the card Element into the `card-element` <div>.
       this.stripe.card.mount('#vsf-stripe-card-element')


### PR DESCRIPTION
Enable the Stripe initialisation optons to be customised via the local.json file. See https://stripe.com/docs/js/elements_object/create_element?type=card